### PR TITLE
Chore/update dates add yt link

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,8 @@
             <p class="mt-3 mx-auto text-base sm:text-lg md:mt-5 md:text-xl">
               Our first meeting is <span class="font-bold text-cyan-500">Wednesday, March 23 at 16:30 UTC</span>.
               A zoom link will be shared in the channel <a href="https://clojurians.slack.com/archives/C038E1MU24Q" class="text-sky-500">#the-clouncil</a> of <a href="https://clojurians.slack.com/join/shared_invite/zt-zjqnhvdj-HSQGSyA79T5qdMb9GwqD1A#/shared-invite/email" class="text-sky-foo">Clojurians slack</a>.
-              Join the Zoom to get your questions answered, or just to hang out and have a good time! (You can attend without speaking or submitting a question 😊)
+              Join the Zoom to get your questions answered, or just to hang out and have a good time! (You can attend without speaking or submitting a question 😊).
+              To see prior episodes, check out our <a href="https://www.youtube.com/channel/UC9zrrTFKT0wUK7Osbk89jog" class="text-sky-500"> Youtube Channel</a>
             </p>
           </div>
         </main>

--- a/index.html
+++ b/index.html
@@ -236,10 +236,10 @@
           <h2 class="text-3xl font-bold text-rose-600">Schedule</h2>
           <p class="my-3">We meet every other Wednesday at 16:30 UTC. Upcoming dates:</p>
           <ul class="list-disc">
-            <li>Wednesday, March 23</li>
-            <li>Wednesday, April 6</li>
-            <li>Wednesday, April 20</li>
-            <li>Wednesday, May 4</li>
+            <li>Wednesday, May 18</li>
+            <li>Wednesday, June 1</li>
+            <li>Wednesday, June 15</li>
+            <li>Wednesday, June 29</li>
           </ul>
         </div>
 


### PR DESCRIPTION
This PR adds the YT link to the intro paragraph and updates the dates to reflect through June 29.

I did not actually look at this in the browser since was only a couple of minor changes.